### PR TITLE
Update Website_to_Embedding.ipynb

### DIFF
--- a/Website_to_Embedding.ipynb
+++ b/Website_to_Embedding.ipynb
@@ -234,7 +234,7 @@
         "#@markdown How long do you want your summary to be\n",
         "max_tokens = 200 #@param {\"type\":\"integer\"}\n",
         "\n",
-        "# base64_image = download_website(url)\n",
+        "base64_image = download_website(url)\n",
         "results = analyse_content(user_prompt, system_prompt, base64_image, max_tokens)\n",
         "\n",
         "print(results)"


### PR DESCRIPTION
Whenever executing the last cell, IPYNB falls thru with NameError exception because of most likely wrongly commented out variable declaration 

"NameError                                 Traceback (most recent call last)
<ipython-input-4-aae7fc2b977b> in <cell line: 20>()
     18 
     19 # base64_image = download_website(url)
---> 20 results = analyse_content(user_prompt, system_prompt, base64_image, max_tokens)
     21 
     22 print(results)

NameError: name 'base64_image' is not defined"